### PR TITLE
Added support for different recharge stations.

### DIFF
--- a/Source/RimsecSecurityContinued/RimsecSecurity/PeacekeeperUtility.cs
+++ b/Source/RimsecSecurityContinued/RimsecSecurity/PeacekeeperUtility.cs
@@ -19,7 +19,7 @@ public class PeacekeeperUtility
 
 	public static Thing GetEmptyChargeStation(Pawn pawn)
 	{
-		if (pawn.Faction == Faction.OfPlayerSilentFail)
+		if (pawn.Faction == Faction.OfPlayerSilentFail && IsPeacekeeper(pawn))
 		{
 			List<ThingDef> ValidBeds = (pawn.def as ThingDef_AlienRace)?.alienRace?.generalSettings?.validBeds?.Select(entry => entry)?.ToList();
 			return (from x in pawn.Map?.listerBuildings.allBuildingsColonist.OfType<Building_ChargeStation>()
@@ -33,7 +33,7 @@ public class PeacekeeperUtility
 
 	public static bool IsInChargeStation(Pawn pawn)
 	{
-		if (pawn != null && pawn.Map != null)
+		if (pawn != null && pawn.Map != null && IsPeacekeeper(pawn))
 		{
 			List<ThingDef> ValidBeds = (pawn.def as ThingDef_AlienRace)?.alienRace?.generalSettings?.validBeds?.Select(entry => entry)?.ToList();
 			return pawn.Position.GetThingList(pawn.Map).Any((Thing x) => ValidBeds.Contains(x.def) && ((Building_ChargeStation)x).CurrentRobot == pawn);

--- a/Source/RimsecSecurityContinued/RimsecSecurity/PeacekeeperUtility.cs
+++ b/Source/RimsecSecurityContinued/RimsecSecurity/PeacekeeperUtility.cs
@@ -21,8 +21,9 @@ public class PeacekeeperUtility
 	{
 		if (pawn.Faction == Faction.OfPlayerSilentFail)
 		{
+			List<ThingDef> ValidBeds = (pawn.def as ThingDef_AlienRace)?.alienRace?.generalSettings?.validBeds?.Select(entry => entry)?.ToList();
 			return (from x in pawn.Map?.listerBuildings.allBuildingsColonist.OfType<Building_ChargeStation>()
-				where (x.CurrentRobot == null || x.CurrentRobot == pawn) && x.def == pawn.def?.GetModExtension<RSPeacekeeperModExt>()?.stationDef && pawn.Map.reservationManager.CanReserve(pawn, x)
+				where (x.CurrentRobot == null || x.CurrentRobot == pawn) && ValidBeds.Contains(x.def) && pawn.Map.reservationManager.CanReserve(pawn, x)
 				select x into station
 				orderby pawn.Position.DistanceTo(station.Position)
 				select station).FirstOrDefault();
@@ -34,7 +35,8 @@ public class PeacekeeperUtility
 	{
 		if (pawn != null && pawn.Map != null)
 		{
-			return pawn.Position.GetThingList(pawn.Map).Any((Thing x) => x.def == pawn.def.GetModExtension<RSPeacekeeperModExt>().stationDef && ((Building_ChargeStation)x).CurrentRobot == pawn);
+			List<ThingDef> ValidBeds = (pawn.def as ThingDef_AlienRace)?.alienRace?.generalSettings?.validBeds?.Select(entry => entry)?.ToList();
+			return pawn.Position.GetThingList(pawn.Map).Any((Thing x) => ValidBeds.Contains(x.def) && ((Building_ChargeStation)x).CurrentRobot == pawn);
 		}
 		return false;
 	}


### PR DESCRIPTION
### Issue
Recharge stations are hardcoded in RSPeacekeeperModExt and does not allow the addition of new ones.

### Proposed solution
Use "validBeds" list from AlienRaceBase.xml to allow the additions of new "beds" in the list.

### Context
I wanted to have a smaller recharge station for use in the gravship but was not able to have both (SRS version and my own) working at the same time when modifying only the xml files.





